### PR TITLE
Fix landing page navigation

### DIFF
--- a/layouts/partials/logo.html
+++ b/layouts/partials/logo.html
@@ -1,5 +1,5 @@
 <a id="logo"
-   href='{{ (cond (and (ne .Site.Params.landingPageURL nil) (.Site.IsMultiLingual)) .Site.Params.landingPageURL "/") }}'>
+   href='{{ (cond (and (ne .Site.Params.landingPageURL nil) (.Site.IsMultiLingual)) .Site.Params.landingPageURL "") | relURL }}'>
    <img src="{{"images/snowplow-logo.svg" | relURL}}"
       style="height: 20px; margin-left: 24px; margin-right: 8px;" />
    <h1>Accelerators</h1>

--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -7,7 +7,7 @@
     {{if not .Site.Params.disableLandingPageButton }}
     <ul class="introduction">
       <a
-        href='{{ (cond (and (ne .Site.Params.landingPageURL nil) (.Site.IsMultiLingual)) .Site.Params.landingPageURL "/") }}'>{{safeHTML
+        href='{{ (cond (and (ne .Site.Params.landingPageURL nil) (.Site.IsMultiLingual)) .Site.Params.landingPageURL "") | relURL }}'>{{safeHTML
         (cond (ne .Site.Params.landingPageName nil) .Site.Params.landingPageName "<i class='fas fa-rocket'></i> Introduction")
         }}</a>
     </ul>


### PR DESCRIPTION
This should allow the landing pages to always point to the correct root of the site (by using `relURL`) when a `landingPageURL` is not specified (which it isn't because it's on the root of the website).