### PR TITLE
Ensure urls always end with trailing slash

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -8,6 +8,13 @@
     {{ partial "favicon.html" . }}
     <title>{{ .Title }} {{ default "::" .Site.Params.titleSeparator }} {{ .Site.Title }}</title>
 
+    <script>
+      // Do this to ensure rewrites on netlify always end with a trailing slash
+      if(!window.location.pathname.endsWith("/")) {
+        window.location = window.location + "/"
+      }
+    </script>
+
     {{ $assetBusting := not .Site.Params.disableAssetsBusting }}
     <link href="{{"css/nucleus.css" | relURL}}{{ if $assetBusting }}?{{ now.Unix }}{{ end }}" rel="stylesheet">
     <link href="{{"css/fontawesome-all.min.css" | relURL}}{{ if $assetBusting }}?{{ now.Unix }}{{ end }}" rel="stylesheet">


### PR DESCRIPTION
This should ensure the trailing slash is applied if someone visits the netlify rewrite without the trailing slash.

https://answers.netlify.com/t/bug-in-non-trailing-slash-rewrite/452/39