### PR TITLE
Add canonical links

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -32,6 +32,7 @@
     {{ range .Site.Params.custom_css -}}
     <link href="{{(printf "%s" .) | relURL}}{{ if $assetBusting }}?{{ now.Unix }}{{ end }}" rel="stylesheet">
     {{- end }}
+    <link rel="canonical" href="{{ .Permalink }}" />
 
     <script src="{{"js/jquery-3.3.1.min.js"| relURL}}{{ if $assetBusting }}?{{ now.Unix }}{{ end }}"></script>
 


### PR DESCRIPTION
This fix prevents deployment previews being indexed by search engines.