### PR TITLE
Separate Snowplow tracker configuration for biz1 tracker

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -51,26 +51,37 @@
   <body class="" data-url="{{ .RelPermalink }}">
     <script type="text/javascript" async=1 >
       ;(function (p, l, o, w, i, n, g) { if (!p[i]) { p.GlobalSnowplowNamespace = p.GlobalSnowplowNamespace || []; p.GlobalSnowplowNamespace.push(i); p[i] = function () { (p[i].q = p[i].q || []).push(arguments) }; p[i].q = p[i].q || []; n = l.createElement(o); g = l.getElementsByTagName(o)[0]; n.async = 1; n.src = w; g.parentNode.insertBefore(n, g) } }(window, document, "script", "{{"js/3.6.0/9LZR5r.js" | relURL}}", "snowplow"));
-      
-      const trackerConfig = {
+    
+      window.snowplow('newTracker', 'snplow5', 'collector.snowplow.io', {
         appId: 'accelerator',
+        eventMethod: 'post',
         cookieDomain: `.snowplow.io`,
         cookieName: '_sp5_',
+        cookieSameSite: 'Lax',
         contexts: {
           webPage: true,
         },
-      }
-    
-      window.snowplow('newTracker', 'snplow5', 'collector.snowplow.io', trackerConfig);
+      });
 
-      window.snowplow('newTracker', 'biz1', 'c.snowplow.io', trackerConfig)
+      window.snowplow('newTracker', 'biz1', 'c.snowplow.io', {
+        appId: 'accelerator',
+        eventMethod: 'post',
+        cookieDomain: `.snowplow.io`,
+        cookieName: '_sp_biz1_',
+        cookieSameSite: 'Lax',
+        contexts: {
+          webPage: true,
+          gaCookies: true,
+          clientHints: true,
+        },
+      });
 
       snowplow('enableActivityTracking', {
         minimumVisitLength: 10,
         heartbeatDelay: 10
       });
 
-      snowplow('trackPageView')
+      snowplow('trackPageView');
 
     </script>
     {{ partial "navbar.html" . }}


### PR DESCRIPTION
Updates the configuraiton for `snplow5` and `biz1` trackers:

* sets the method to POST on both trackers
* sets `cookieSameSite` to `Lax` on both trackers
* changes the `cookieName` for `biz1` tracker
* enables `gaCookies` and `clientHints` context entities on the `biz1` tracker (not sure if this should also apply for `snplow5`)