### PR TITLE
Add markup to open extlinks as new tab

### DIFF
--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,0 +1,1 @@
+<a href="{{ .Destination | safeURL }}"{{ with .Title}} title="{{ . }}"{{ end }}{{ if or (strings.HasPrefix .Destination "http") (strings.HasPrefix .Destination "https") }} target="_blank"{{ end }} >{{ .Text | safeHTML }}</a>


### PR DESCRIPTION
## Description & motivation

There has been a new request to change the default behaviour of Hugo and open any external links on a new tab. I found the [following](https://digitaldrummerj.me/hugo-links-to-other-pages/), which I implemented locally using the consent-accelerator, which worked fine. After agreeing with Craig it was decided we should set this as a default behaviour for all accelerators.