### PR TITLE
Add scrolling to Jupyter notebook shortcode

### DIFF
--- a/layouts/shortcodes/jupyter.html
+++ b/layouts/shortcodes/jupyter.html
@@ -1,3 +1,3 @@
 <h3><a href="../static/{{ index .Params 0 }}.html">Click here to view this notebook in full screen</a></h3>
 <iframe src="../static/{{ index .Params 0 }}.html"
-    style="height:{{ index .Params 1}}px;width:100%;border:none;overflow:hidden;" scrolling="no"></iframe>
+    style="height:{{ index .Params 1}}px;width:100%;border:none;overflow:hidden;" scrolling="yes"></iframe>


### PR DESCRIPTION
The html export of the new Snowflake Jupyter notebooks doesn't allow scrolling like the Databricks ones (see [example](https://deploy-preview-16--snowplow-axl-cdp-ml-modeling.netlify.app/accelerators/composable-cdp-with-predictive-ml-modeling/predictive_ml_models/snowflake_model_training/)). Changing scrolling to "yes" fixes this. I've tested locally for both notebooks.